### PR TITLE
すでに医療費を登録済みだった場合、支払先・家族を消すとエラーが出るようにする

### DIFF
--- a/app/controllers/family_members_controller.rb
+++ b/app/controllers/family_members_controller.rb
@@ -32,7 +32,11 @@ class FamilyMembersController < ApplicationController
   
   def destroy
     @family_member.destroy
-    redirect_to user_family_members_path, notice: "#{@family_member.name} を削除しました"
+    if @family_member.errors.present?
+      redirect_to user_family_members_path, notice: "#{@family_member.name} は関連する医療費があるため、削除できませんでした" 
+    else
+      redirect_to user_family_members_path, notice: "#{@family_member.name} を削除しました"
+    end
   end
 
   private

--- a/app/controllers/payees_controller.rb
+++ b/app/controllers/payees_controller.rb
@@ -32,7 +32,11 @@ class PayeesController < ApplicationController
   
   def destroy
     @payee.destroy
-    redirect_to user_payees_path, notice: "#{@payee.name} を削除しました"
+    if @payee.errors.present?
+      redirect_to user_payees_path, notice: "#{@payee.name} は関連する医療費があるため、削除できませんでした" 
+    else
+      redirect_to user_payees_path, notice: "#{@payee.name} を削除しました"
+    end
   end
 
   private

--- a/app/models/family_member.rb
+++ b/app/models/family_member.rb
@@ -1,6 +1,6 @@
 class FamilyMember < ApplicationRecord
   belongs_to :user
-  has_many :medical_bill
+  has_many :medical_bills, dependent: :restrict_with_error
 
   validates :name, presence: true
 end

--- a/app/models/payee.rb
+++ b/app/models/payee.rb
@@ -1,6 +1,6 @@
 class Payee < ApplicationRecord
   belongs_to :user
-  has_many :medical_bills
+  has_many :medical_bills, dependent: :restrict_with_error
   
   validates :name, presence: true
 end


### PR DESCRIPTION
[すでに医療費を登録済みだった場合、支払先・家族を消すとエラーになる · Issue #59 · lime1024/medireco](https://github.com/lime1024/medireco/issues/59)