### PR TITLE
出力年未選択のときは index にリダイレクトするようにする

### DIFF
--- a/app/controllers/medical_bills_controller.rb
+++ b/app/controllers/medical_bills_controller.rb
@@ -7,6 +7,10 @@ class MedicalBillsController < ApplicationController
         render :index
       end
       format.xlsx do
+        if params[:year].blank?
+          redirect_to medical_bills_path(format: :html), notice: "出力年を選択してください"
+          return
+        end
         output = MedicalBillOutput.new(user: current_user, year: params[:year])
         begin
           workbook = output.as_xlsx


### PR DESCRIPTION
[出力年を選択せずに出力を押すとエラーになる · Issue #85 · lime1024/medireco](https://github.com/lime1024/medireco/issues/85)