### PR TITLE
意図がわかりづらい scope を削除する

### DIFF
--- a/app/controllers/medical_bills_controller.rb
+++ b/app/controllers/medical_bills_controller.rb
@@ -3,7 +3,10 @@ class MedicalBillsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        @medical_bills = current_user.medical_bills.preload(:family_member, :payee).recent.page(params[:page])
+        @medical_bills = current_user.medical_bills
+          .preload(:family_member, :payee)
+          .order(day: :desc, created_at: :desc)
+          .page(params[:page])
         render :index
       end
       format.xlsx do

--- a/app/models/medical_bill.rb
+++ b/app/models/medical_bill.rb
@@ -3,7 +3,6 @@ class MedicalBill < ApplicationRecord
   belongs_to :family_member
   belongs_to :payee
 
-  scope :recent, -> { order(day: :desc, created_at: :desc) }
   scope :search, -> (search) { where("day BETWEEN ? AND ?", "#{search}-01-01", "#{search}-12-31") }
   scope :this_year, -> {
     today_year = Date.today.year


### PR DESCRIPTION
- recent という名前から挙動を推察しづらい
- 直接 order を書いたほうが意図が通じやすい