### PR TITLE
Fix truncate label

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,7 @@ ja:
       previous: "<"
       next: ">"
       last: ">>"
+      truncate: "&hellip;"
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
translation がないため "Truncate" と表示されていた

---

これが

![Screenshot from 2020-05-16 19-04-30](https://user-images.githubusercontent.com/3321320/82116922-1c1a3180-97a8-11ea-9641-ce586552e865.png)

こう

![Screenshot from 2020-05-16 19-05-07](https://user-images.githubusercontent.com/3321320/82116934-2f2d0180-97a8-11ea-8952-ba0166cc9f33.png)