### PR TITLE
医療費登録画面から家族登録・支払先登録画面に遷移したときの warning を消す

### DIFF
--- a/app/controllers/family_members_controller.rb
+++ b/app/controllers/family_members_controller.rb
@@ -46,7 +46,7 @@ class FamilyMembersController < ApplicationController
   private
 
   def family_member_params
-    params.require(:family_member).permit(:name)
+    params.require(:family_member).except(:from).permit(:name)
   end
 
   def set_family_menmber

--- a/app/controllers/payees_controller.rb
+++ b/app/controllers/payees_controller.rb
@@ -45,7 +45,7 @@ class PayeesController < ApplicationController
   private
 
   def payee_params
-    params.require(:payee).permit(:name)
+    params.require(:payee).except(:from).permit(:name)
   end
 
   def set_payee


### PR DESCRIPTION
## やったこと
- モデルに必要ないパラメータなので、除外した

## なぜなのか
close #182
- 医療費登録画面から以下の画面に遷移したときに warning が出るから
  - 家族登録
  - 支払先登録