### PR TITLE
エクセルの合計金額をエクセルの計算式に任せる (不具合修正)

### DIFF
--- a/app/models/medical_bill_output.rb
+++ b/app/models/medical_bill_output.rb
@@ -3,15 +3,12 @@ require 'rubyXL/convenience_methods'
 class MedicalBillOutput
   def initialize(user:, year:)
     @medical_bills = user.medical_bills.search(year).summarized_output
-    @total_cost = user.medical_bills.sum(:cost)
   end
 
   def as_xlsx
     workbook = RubyXL::Parser.parse(Rails.root.join("template", "template.xlsx"))
     sheet = workbook.first
 
-    sheet[2][2].change_contents(@total_cost) # 合計金額
-    
     num = 8
 
     @medical_bills.each.with_index(1) do |medical_bill, index|

--- a/spec/models/medical_bill_output_spec.rb
+++ b/spec/models/medical_bill_output_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe MedicalBillOutput, type: :model do
       FactoryBot.create(:family_member, user: user)
       FactoryBot.create(:payee, user: user)
       FactoryBot.create(:medical_bill, day: Date.new(2019, 01, 01), cost: 100, user: user)
+      FactoryBot.create(:medical_bill, day: Date.new(2020, 01, 01), cost: 999, user: user)
 
       workbook = described_class.new(user: user, year: 2019).as_xlsx
       sheet = workbook.first
 
       expect(workbook).to be_a RubyXL::Workbook
-      expect(sheet[2][2].value).to eq 100
+      expect(sheet[2][2].value).to eq ""
       expect(sheet[8][0].value).to eq 1
       expect(sheet[8][1].value).to eq user.family_members.first.name
       expect(sheet[8][2].value).to eq user.payees.first.name


### PR DESCRIPTION
## やりたいこと
- エクセルに出力される合計金額をエクセルの計算式に任せたい
  - 国税庁で用意されているフォーマットに計算式がデフォルトで入っているから

## なぜやるか
- 合計金額が出力したい年のものだけじゃなくて、過去全部の合計金額になっていた
  - お父さんからの申告内容

## やったこと
- 出力したい年の合計金額をアプリ側ではエクセルに書き込まないようにした