### PR TITLE
ログイン済みの場合 / は /medical_bills にリダイレクトする

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,7 @@ class HomeController < ApplicationController
   skip_before_action :login_required
   
   def index
+    redirect_to medical_bills_path if current_user
   end
 
   def policy

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Home', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'ログインしている場合' do
+    before do
+      login(user)
+    end
+
+    it 'root にアクセスすると medical_bills にリダイレクトされること' do
+      get root_path
+      expect(response).to redirect_to(medical_bills_path)
+    end
+  end
+
+  context 'ログインしていない場合' do
+    it 'root にアクセスすると medical_bills にリダイレクトされないこと' do
+      get root_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
- ログイン済みの場合 `/` を `/medicall_bills` にリダイレクトする

## なぜやったか
- ログインしているときにログイン画面に遷移する必要がないから

close #201 