### PR TITLE
デザインを修正する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -106,6 +106,8 @@ html {
       flex: 1;
       display: flex;
       flex-direction: row;
+      max-width: 980px;
+      margin: 0 auto;
       .container-sessions {
         flex-basis: 40%;
         text-align: center;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -179,30 +179,28 @@ html {
       background-color: #5B5B5B;
       padding-top: 1rem;
       padding-bottom: 1rem;
-      .footer {
-        h2 {
-          font-size: 1.2rem;
+      h2 {
+        font-size: 1.2rem;
+        color: white;
+      }
+      h3 {
+        font-size: 1.2rem;
+        margin-top: 0.5rem;
+        color: white;
+        a {
           color: white;
         }
-        h3 {
-          font-size: 1.2rem;
-          margin-top: 0.5rem;
-          color: white;
-          a {
-            color: white;
-          }
-          .policy {
-            margin-right: 0.5rem;
-          }
-          .policy:hover {
-            text-decoration: underline;
-          }
-          .disclaimer {
-            margin-left: 0.5rem;
-          }
-          .disclaimer:hover {
-            text-decoration: underline;
-          }
+        .policy {
+          margin-right: 0.5rem;
+        }
+        .policy:hover {
+          text-decoration: underline;
+        }
+        .disclaimer {
+          margin-left: 0.5rem;
+        }
+        .disclaimer:hover {
+          text-decoration: underline;
         }
       }
     }

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -33,9 +33,8 @@ html
           .alert.alert_success = flash.notice
       = yield
     footer
-      .footer
-        .footer-copyright
-        h2 Copyright 2019 Ai Kiriyama
-        h3
-          = link_to 'プライバシーポリシー', policy_path, class: 'policy'
-          = link_to '免責事項', disclaimer_path, class: 'disclaimer'
+      .footer-copyright
+      h2 Copyright 2019 Ai Kiriyama
+      h3
+        = link_to 'プライバシーポリシー', policy_path, class: 'policy'
+        = link_to '免責事項', disclaimer_path, class: 'disclaimer'


### PR DESCRIPTION
## やったこと
- 町田さんから指摘されていたデザインの修正を一部対応
  - `footer` の中に `.footer` があったので `.footer` を削除して階層を一つあげた
  - `/` で画面サイズが大きい場合でも中心に表示されるようにした

close #148
close #146